### PR TITLE
feat(sort): Sorting the request response

### DIFF
--- a/src/components/movies-list.js
+++ b/src/components/movies-list.js
@@ -25,7 +25,7 @@ export function MoviesList(props) {
                 <td><img src={movie.artworkUrl100} /></td>
                 <td>{movie.releaseYear}</td>
                 <td>{movie.trackName}</td>
-                <td>{`$${movie.trackHdPrice}`}</td>
+                <td>{movie.trackHdPrice}</td>
                 <td>{movie.longDescription}</td>
               </tr>
             )

--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -39,12 +39,12 @@ export function getPopularMovies () {
               // Adding the releaseYear attribute after doing a preliminary regex test for release date of format YYYY-MM-DDTHH:MM:SSZ
               if(typeof movie.releaseDate == "string" && reHasRsDate.test(movie.releaseDate)) {
                 // Split the releaseDate by the date separator
-                currentMovie.releaseYear = movie.releaseDate.split(rsDateSeparator).shift()
+                currentMovie.releaseYear = movie.releaseDate.split(rsDateSeparator).shift() || "Not Available"
               }
-              currentMovie.artworkUrl100 = movie.artworkUrl100
-              currentMovie.trackName = movie.trackName
-              currentMovie.trackHdPrice = movie.trackHdPrice
-              currentMovie.longDescription = movie.longDescription
+              currentMovie.artworkUrl100 = movie.artworkUrl100 || "Not Available"
+              currentMovie.trackName = movie.trackName || "Not Available"
+              currentMovie.trackHdPrice = movie.trackHdPrice ? ("$"+movie.trackHdPrice) : "Not Available"
+              currentMovie.longDescription = movie.longDescription || "Not Available"
 
               combinedResults.push(currentMovie)
             })


### PR DESCRIPTION
This PR adds a new feature to this project

- Combining the request response from the two API requests

- Added a **releaseYear** field for each movie from the list
 
- Sort the list of movies primarily based on year and secondarily later by title

- **Not Available** is displayed when any of the attribute don't have values

- Modified the trackHdPrice template string in the view to not contain **$** by default to encounter bullet 4

Files modified [src/components/movies-list.js, src/state/actions.js]

For final result refer:
 
![movielist](https://cloud.githubusercontent.com/assets/2215851/16970605/370ff4c6-4deb-11e6-9b51-edce04538405.png)
